### PR TITLE
Update 10_wavefront.yaml

### DIFF
--- a/deploy/helm/templates/10_wavefront.yaml
+++ b/deploy/helm/templates/10_wavefront.yaml
@@ -29,7 +29,7 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: WAVEFRONT_URL
-          value: https://longboard.wavefront.com/api/
+          value: {{ .Values.wavefront.url }}
         - name: WAVEFRONT_TOKEN
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
WAVEFRONT_URL has to be configured to the url set in values.yaml. The current setting always assumes the wavefront cluster would be longboard, which may not be correct all the time.